### PR TITLE
Ignore generated rhythmbox.appdata.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,7 @@ widgets/test-uri-dialog
 
 plugins/audiocd/test-cd
 plugins/rb/rbconfig.py
+
+
+#
+data/rhythmbox.appdata.xml


### PR DESCRIPTION
The missing rhythmbox.appdata.xml.in recent bugfix now generates a file during compilation, which isn't needed to be tracked by git. So ignore it.
