### PR TITLE
Print command output's repr() instead of str()

### DIFF
--- a/plugins/pythonconsole/pythonconsole.py
+++ b/plugins/pythonconsole/pythonconsole.py
@@ -393,7 +393,7 @@ class PythonConsole(Gtk.ScrolledWindow):
 			try:
 				r = eval(command, self.namespace, self.namespace)
 				if r is not None:
-					print(r)
+					print(repr(r))
 			except SyntaxError:
 				exec(command, self.namespace)
 		except:


### PR DESCRIPTION
This is how the original python console behaves. Using `repr` disambiguates output for certain types, such as `str`.

Example before this commit: input is `str`, but output looks like `bool`:
```
>>> 'True'
True
```

Example after this commit:
```
>>> 'True'
'True'
```