### PR TITLE
fix albumart width in webremote ui

### DIFF
--- a/plugins/webremote/css/webremote.css
+++ b/plugins/webremote/css/webremote.css
@@ -33,14 +33,14 @@ div#trackimage {
 }
 img.albumart {
 	height: 100%;
-	width: auto;
+	max-width: 100%;
 	margin: 10px auto;
 	display: block;
 	border: 0.1rem solid black;
 }
 img.noalbumart {
 	height: 100%;
-	width: auto;
+	max-width: 100%;
 	margin: 10px auto;
 	display: block;
 	border: none;


### PR DESCRIPTION
(I couldn't find how to submit a PR on gitlab)

Tracks have different resolution albumart. This change makes sure that hi-res albumart doesn't become too big in the webremote ui (see images below)

![before](https://user-images.githubusercontent.com/2451971/48146526-7b46de00-e2b5-11e8-8dc1-e7efb04e53e6.png)
![after](https://user-images.githubusercontent.com/2451971/48146524-7aae4780-e2b5-11e8-99a9-bcaeefebb0d3.png)


