### PR TITLE
Optimize symbolic icon SVGs of plugins

### DIFF
--- a/plugins/audioscrobbler/icons/hicolor/scalable/places/Last.fm-symbolic.svg
+++ b/plugins/audioscrobbler/icons/hicolor/scalable/places/Last.fm-symbolic.svg
@@ -1,110 +1,17 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="256"
-   height="256"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="Last.fm-icon.svg">
-  <metadata
-     id="metadata22">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <metadata>
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1023"
-     inkscape:window-height="623"
-     id="namedview20"
-     showgrid="false"
-     inkscape:zoom="1.147955"
-     inkscape:cx="5.64927"
-     inkscape:cy="128"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg2" />
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient4845">
-      <stop
-         stop-color="#d01f3c"
-         id="stop4847"
-         offset="0" />
-      <stop
-         stop-color="#d01f3c"
-         id="stop4853"
-         offset="0.5" />
-      <stop
-         stop-color="#d32c48"
-         id="stop4855"
-         offset="0.5" />
-      <stop
-         stop-color="#eb9fab"
-         id="stop4849"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4845"
-       id="linearGradient4851"
-       y2="119.94179"
-       x2="239.74998"
-       y1="263.20898"
-       x1="239.74998" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4845"
-       id="linearGradient4862"
-       y2="119.94179"
-       x2="239.74998"
-       y1="263.20898"
-       x1="239.74998" />
-    <linearGradient
-       xlink:href="#linearGradient4845"
-       id="linearGradient1433"
-       y2="-0.003883"
-       x2="0.48083"
-       y1="0.828193"
-       x1="0.48083" />
-  </defs>
-  <g
-     id="g14"
-     style="fill:#000000;fill-opacity:1"
-     transform="matrix(1.252481,0,0,1.252481,-32.31757,-34.560638)">
-    <title
-       id="title16">Layer 1</title>
-    <g
-       display="inline"
-       id="layer1"
-       style="fill:#000000;fill-opacity:1;display:inline">
-      <path
-         id="path1952"
-         d="m 147.74242,158.95406 -2.13848,-4.94561 -18.38383,-43.738 C 121.1484,94.791222 106.01414,84.332604 88.955123,84.332604 c -23.083221,0 -41.808273,19.551186 -41.808273,43.679266 0,24.10559 18.725052,43.66802 41.808273,43.66802 16.114137,0 30.097307,-9.51625 37.080137,-23.44442 l 7.43277,17.89389 c -10.54111,13.4345 -26.57776,21.99088 -44.512907,21.99088 -31.794575,0 -57.561203,-26.89397 -57.561203,-60.10837 0,-33.213148 25.766628,-60.132109 57.561203,-60.132109 23.991857,0 43.369327,13.371986 53.216777,37.087639 0.7349,1.84101 10.40238,25.43291 18.84252,45.51403 5.21182,12.41962 9.66122,20.67602 24.10934,21.18097 14.16063,0.50117 23.92186,-8.50014 23.92186,-19.90239 0,-11.13728 -7.44902,-13.81444 -19.97238,-18.16762 -22.50955,-7.74273 -34.15178,-15.52921 -34.15178,-34.179275 0,-18.193863 11.84221,-30.328514 31.11467,-30.328514 12.53586,0 21.60967,5.832977 27.89635,17.455208 L 201.5966,93.11019 c -4.6244,-6.771614 -9.74873,-9.453751 -16.24788,-9.453751 -9.04879,0 -15.48545,6.571632 -15.48545,15.304253 0,12.400868 10.62361,14.266868 25.47164,19.348708 19.98488,6.79661 29.27117,14.56809 29.27117,33.95303 0,20.36484 -16.72281,35.20414 -38.56995,35.16664 -20.12236,-0.09 -30.86094,-10.36488 -38.29371,-28.47502"
-         style="fill:#000000;fill-opacity:1;fill-rule:nonzero"
-         inkscape:connector-curvature="0" />
+  <g transform="matrix(1.2525 0 0 1.2525 -32.318 -34.561)">
+    <title>Layer 1</title>
+    <g>
+      <path d="m147.74 158.95-2.1385-4.9456-18.384-43.738c-6.0717-15.479-21.206-25.938-38.265-25.938-23.083 0-41.808 19.551-41.808 43.679 0 24.106 18.725 43.668 41.808 43.668 16.114 0 30.097-9.5162 37.08-23.444l7.4328 17.894c-10.541 13.434-26.578 21.991-44.513 21.991-31.795 0-57.561-26.894-57.561-60.108 0-33.213 25.767-60.132 57.561-60.132 23.992 0 43.369 13.372 53.217 37.088 0.7349 1.841 10.402 25.433 18.843 45.514 5.2118 12.42 9.6612 20.676 24.109 21.181 14.161 0.50117 23.922-8.5001 23.922-19.902 0-11.137-7.449-13.814-19.972-18.168-22.51-7.7427-34.152-15.529-34.152-34.179 0-18.194 11.842-30.329 31.115-30.329 12.536 0 21.61 5.833 27.896 17.455l-12.336 6.5704c-4.6244-6.7716-9.7487-9.4538-16.248-9.4538-9.0488 0-15.485 6.5716-15.485 15.304 0 12.401 10.624 14.267 25.472 19.349 19.985 6.7966 29.271 14.568 29.271 33.953 0 20.365-16.723 35.204-38.57 35.167-20.122-0.09-30.861-10.365-38.294-28.475"/>
     </g>
   </g>
 </svg>

--- a/plugins/magnatune/icons/hicolor/scalable/places/magnatune-symbolic.svg
+++ b/plugins/magnatune/icons/hicolor/scalable/places/magnatune-symbolic.svg
@@ -1,84 +1,17 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   width="65"
-   height="67"
-   sodipodi:docname="magnatune-icon.svg">
-  <metadata
-     id="metadata8">
+<svg version="1.1" viewBox="0 0 65 67" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <metadata>
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs6" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="746"
-     id="namedview4"
-     showgrid="false"
-     inkscape:zoom="6.1757813"
-     inkscape:cx="5.5214775"
-     inkscape:cy="32.825251"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
-  <rect
-     style="fill-opacity:1;stroke:none"
-     id="rect5207"
-     width="6.6503477"
-     height="20.48934"
-     x="18.777695"
-     y="27.631033"
-     rx="1.1780093"
-     ry="1.144017" />
-  <rect
-     style="fill-opacity:1;stroke:none"
-     id="rect5209"
-     width="6.6503477"
-     height="32.081989"
-     x="29.950281"
-     y="16.03838"
-     rx="1.1780093"
-     ry="1.144017" />
-  <rect
-     style="fill-opacity:1;stroke:none"
-     id="rect5211"
-     width="6.6503477"
-     height="20.48934"
-     x="40.324821"
-     y="27.631033"
-     rx="1.1780093"
-     ry="1.144017" />
-  <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:5.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="m 32.505554,1.207602 c -17.889667,0 -32.45987484,14.570208 -32.45987484,32.459875 0,17.889666 14.57020784,32.459874 32.45987484,32.459874 17.827626,0 32.323394,-14.475792 32.423967,-32.28034 a 3.1601268,3.1601268 0 0 0 0.03591,-0.251348 3.1601268,3.1601268 0 0 0 0,-0.07181 3.1601268,3.1601268 0 0 0 0,-0.215442 C 64.770655,15.557474 50.257556,1.207602 32.505554,1.207602 z m 0,6.3196216 c 14.361144,0 25.982684,11.4927174 26.140253,25.8529974 a 3.1601268,3.1601268 0 0 0 0,0.07181 3.1601268,3.1601268 0 0 0 0,0.215442 c 0,14.47429 -11.665963,26.140253 -26.140253,26.140253 -14.474291,0 -26.1402532,-11.665963 -26.1402532,-26.140253 0,-14.474291 11.6659622,-26.1402534 26.1402532,-26.1402534 z"
-     id="path2986"
-     inkscape:connector-curvature="0" />
+  <rect x="18.778" y="27.631" width="6.6503" height="20.489" rx="1.178" ry="1.144"/>
+  <rect x="29.95" y="16.038" width="6.6503" height="32.082" rx="1.178" ry="1.144"/>
+  <rect x="40.325" y="27.631" width="6.6503" height="20.489" rx="1.178" ry="1.144"/>
+  <path d="m32.506 1.2076c-17.89 0-32.46 14.57-32.46 32.46 0 17.89 14.57 32.46 32.46 32.46 17.828 0 32.323-14.476 32.424-32.28a3.1601 3.1601 0 0 0 0.03591-0.25135 3.1601 3.1601 0 0 0 0-0.07181 3.1601 3.1601 0 0 0 0-0.21544c-0.19478-17.751-14.708-32.101-32.46-32.101zm0 6.3196c14.361 0 25.983 11.493 26.14 25.853a3.1601 3.1601 0 0 0 0 0.07181 3.1601 3.1601 0 0 0 0 0.21544c0 14.474-11.666 26.14-26.14 26.14-14.474 0-26.14-11.666-26.14-26.14 0-14.474 11.666-26.14 26.14-26.14z" color="#000000" style="block-progression:tb;text-indent:0;text-transform:none"/>
 </svg>

--- a/plugins/soundcloud/icons/hicolor/scalable/places/soundcloud-symbolic.svg
+++ b/plugins/soundcloud/icons/hicolor/scalable/places/soundcloud-symbolic.svg
@@ -1,63 +1,14 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 -64 16 6.9375"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.5 r10040"
-   width="64"
-   height="64"
-   sodipodi:docname="bf_soundcloud.svg">
-  <metadata
-     id="metadata12">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" version="1.1" viewBox="0 -64 16 6.9375" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <metadata>
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs10" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1166"
-     inkscape:window-height="884"
-     id="namedview8"
-     showgrid="false"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     inkscape:zoom="7.375"
-     inkscape:cx="-9.3559322"
-     inkscape:cy="23.078919"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg2" />
-  <g
-     transform="matrix(0.03125,0,0,-0.03125,0,-54.5)"
-     id="g4">
-    <path
-       d="m 6,171 v 0 0 0 c 1,0 2,-1 2,-2 l 4,-29 -4,-28 v 0 0 0 c 0,-1 -1,-2 -2,-2 -1,0 -2,1 -2,2 l -4,28 4,29 c 0,1 1,2 2,2 z m 21,15 v 0 0 0 l 6,-46 -6,-45 c 0,-1 -1,-2 -2,-2 -1,0 -2,1 -2,2 l -5,45 5,46 c 0,1 1,2 2,2 1,0 2,-1 2,-2 z m 79,43 v 0 0 0 c 2,0 4,-2 4,-4 l 4,-85 -4,-54 v 0 c 0,-2 -2,-4 -4,-4 -2,0 -4,2 -4,4 l -4,54 4,85 c 0,2 2,4 4,4 z M 65,199 v 0 0 0 c 2,0 3,-1 3,-3 l 5,-56 -5,-54 c 0,-2 -1,-3 -3,-3 -2,0 -3,1 -3,3 l -4,54 4,56 c 0,2 1,3 3,3 z M 148,82 v 0 0 c -3,0 0,0 0,0 -3,0 -5,2 -5,5 l -3,53 3,113 c 0,3 2,5 5,5 3,0 5,-2 5,-5 l 3,-113 -3,-53 c 0,-3 -2,-5 -5,-5 z m 85,0 v 0 0 c -4,0 0,0 0,0 -4,0 -6,2 -6,6 l -3,52 3,130 c 0,4 2,7 6,7 4,0 7,-3 7,-7 l 3,-130 -3,-52 v 0 0 c 0,-4 -3,-6 -7,-6 z m -43,0 v 0 0 c -3,0 0,0 0,0 -3,0 -5,3 -5,6 l -3,53 3,113 c 0,3 2,6 5,6 3,0 6,-3 6,-6 l 3,-113 -3,-53 v 0 c 0,-3 -3,-6 -6,-6 z M 85,82 v 0 0 c -2,0 0,0 0,0 -2,0 -3,2 -3,4 l -4,54 4,52 c 0,2 1,4 3,4 2,0 4,-2 4,-4 l 5,-52 -5,-54 c 0,-2 -2,-4 -4,-4 z m -40,3 v 0 0 c -1,0 0,0 0,0 -1,0 -3,2 -3,3 l -5,52 5,55 c 0,1 2,3 3,3 1,0 2,-2 2,-3 l 6,-55 -6,-52 c 0,-1 -1,-3 -2,-3 z m 167,171 v 0 0 0 c 3,0 6,-3 6,-6 l 3,-109 -3,-53 v 0 c 0,-3 -3,-6 -6,-6 -3,0 -6,3 -6,6 l -3,53 3,109 c 0,3 3,6 6,6 z M 127,82 v 0 0 c -2,0 0,0 0,0 -2,0 -5,2 -5,4 l -3,54 3,104 c 0,2 3,5 5,5 2,0 4,-3 4,-5 l 4,-104 -4,-54 c 0,-2 -2,-4 -4,-4 z m 47,5 v 0 0 0 0 c 0,-3 -2,-5 -5,-5 -3,0 -5,2 -5,5 l -3,54 3,116 c 0,3 2,5 5,5 3,0 5,-2 5,-5 l 4,-116 -4,-54 v 0 z m 81,202 v 0 0 0 c 4,0 7,-3 7,-7 l 3,-142 -3,-51 v 0 c 0,-4 -3,-7 -7,-7 -4,0 -7,3 -7,7 l -3,51 3,142 c 0,4 3,7 7,7 z m 194,-81 v 0 0 0 c 35,0 63,-28 63,-63 0,-35 -28,-63 -63,-63 H 274 c -4,0 -6,3 -6,7 v 200 c 0,4 1,5 6,7 12,5 26,8 40,8 58,0 106,-44 111,-101 8,3 15,5 24,5 z"
-       id="path6"
-       inkscape:connector-curvature="0"
-       style="fill:currentColor" />
+  <g transform="matrix(.03125 0 0 -.03125 0 -54.5)">
+    <path d="m6 171c1 0 2-1 2-2l4-29-4-28c0-1-1-2-2-2s-2 1-2 2l-4 28 4 29c0 1 1 2 2 2zm21 15 6-46-6-45c0-1-1-2-2-2s-2 1-2 2l-5 45 5 46c0 1 1 2 2 2s2-1 2-2zm79 43c2 0 4-2 4-4l4-85-4-54c0-2-2-4-4-4s-4 2-4 4l-4 54 4 85c0 2 2 4 4 4zm-41-30c2 0 3-1 3-3l5-56-5-54c0-2-1-3-3-3s-3 1-3 3l-4 54 4 56c0 2 1 3 3 3zm83-117c-3 0 0 0 0 0-3 0-5 2-5 5l-3 53 3 113c0 3 2 5 5 5s5-2 5-5l3-113-3-53c0-3-2-5-5-5zm85 0c-4 0 0 0 0 0-4 0-6 2-6 6l-3 52 3 130c0 4 2 7 6 7s7-3 7-7l3-130-3-52c0-4-3-6-7-6zm-43 0c-3 0 0 0 0 0-3 0-5 3-5 6l-3 53 3 113c0 3 2 6 5 6s6-3 6-6l3-113-3-53c0-3-3-6-6-6zm-105 0c-2 0 0 0 0 0-2 0-3 2-3 4l-4 54 4 52c0 2 1 4 3 4s4-2 4-4l5-52-5-54c0-2-2-4-4-4zm-40 3c-1 0 0 0 0 0-1 0-3 2-3 3l-5 52 5 55c0 1 2 3 3 3s2-2 2-3l6-55-6-52c0-1-1-3-2-3zm167 171c3 0 6-3 6-6l3-109-3-53c0-3-3-6-6-6s-6 3-6 6l-3 53 3 109c0 3 3 6 6 6zm-85-174c-2 0 0 0 0 0-2 0-5 2-5 4l-3 54 3 104c0 2 3 5 5 5s4-3 4-5l4-104-4-54c0-2-2-4-4-4zm47 5c0-3-2-5-5-5s-5 2-5 5l-3 54 3 116c0 3 2 5 5 5s5-2 5-5l4-116-4-54zm81 202c4 0 7-3 7-7l3-142-3-51c0-4-3-7-7-7s-7 3-7 7l-3 51 3 142c0 4 3 7 7 7zm194-81c35 0 63-28 63-63s-28-63-63-63h-175c-4 0-6 3-6 7v200c0 4 1 5 6 7 12 5 26 8 40 8 58 0 106-44 111-101 8 3 15 5 24 5z" fill="currentColor"/>
   </g>
 </svg>


### PR DESCRIPTION
Ran Inkscape's built-in optimizer and cleaned up SVG files. Inkscape normally saves SVG with lot of extra data while optimizers keep only the necessary ones without affecting the actual image itself. This is the command I ran:

    for file in *.svg; do scour -i "$file" -o "$file"opt --set-precision=5 --renderer-workaround --enable-viewboxing --indent=space --nindent=2 --strip-xml-space --enable-id-stripping --protect-ids-noninkscape; mv -- "$file"opt "$file"; done